### PR TITLE
feat: Port libcxx ABI interface to Helix

### DIFF
--- a/helix/pkgs/cxxabi_config.hlx
+++ b/helix/pkgs/cxxabi_config.hlx
@@ -1,0 +1,102 @@
+//===----------------------------------------------------------------------===//
+//
+// Port of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+eval if !defined!(____CXXABI_CONFIG_H) {
+    define ____CXXABI_CONFIG_H;
+
+    eval if defined(__arm__) && !defined(__USING_SJLJ_EXCEPTIONS__) && !defined(__ARM_DWARF_EH__) && !defined(__SEH__) {
+        ffi define _LIBCXXABI_ARM_EHABI;
+    }
+
+    eval if !defined(__has_attribute) {
+        ffi define __has_attribute!(_attribute_): 0;
+    }
+
+    eval if defined(__clang__) {
+        ffi define _LIBCXXABI_COMPILER_CLANG;
+    } else if !defined(__apple_build_version__) {
+        ffi define _LIBCXXABI_CLANG_VER: (__clang_major__ * 100 + __clang_minor__);
+    } else if defined(__GNUC__) {
+        ffi define _LIBCXXABI_COMPILER_GCC;
+    } else if defined(_MSC_VER) {
+        ffi define _LIBCXXABI_COMPILER_MSVC;
+    } else if defined(__IBMCPP__) {
+        ffi define _LIBCXXABI_COMPILER_IBM;
+    }
+
+    eval if defined(_WIN32) {
+        eval if defined(_LIBCXXABI_DISABLE_VISIBILITY_ANNOTATIONS) || (defined(__MINGW32__) && !defined(_LIBCXXABI_BUILDING_LIBRARY)) {
+            ffi define _LIBCXXABI_HIDDEN;
+            ffi define _LIBCXXABI_DATA_VIS;
+            ffi define _LIBCXXABI_FUNC_VIS;
+            ffi define _LIBCXXABI_TYPE_VIS;
+        } else if defined(_LIBCXXABI_BUILDING_LIBRARY) {
+            ffi define _LIBCXXABI_HIDDEN;
+            ffi define _LIBCXXABI_DATA_VIS: __declspec(dllexport);
+            ffi define _LIBCXXABI_FUNC_VIS: __declspec(dllexport);
+            ffi define _LIBCXXABI_TYPE_VIS: __declspec(dllexport);
+        } else {
+            ffi define _LIBCXXABI_HIDDEN;
+            ffi define _LIBCXXABI_DATA_VIS: __declspec(dllimport);
+            ffi define _LIBCXXABI_FUNC_VIS: __declspec(dllimport);
+            ffi define _LIBCXXABI_TYPE_VIS: __declspec(dllimport);
+        }
+    } else {
+        eval if !defined(_LIBCXXABI_DISABLE_VISIBILITY_ANNOTATIONS) {
+            ffi define _LIBCXXABI_HIDDEN: __attribute__((__visibility__("hidden")));
+            ffi define _LIBCXXABI_DATA_VIS: __attribute__((__visibility__("default")));
+            ffi define _LIBCXXABI_FUNC_VIS: __attribute__((__visibility__("default")));
+        } eval if __has_attribute(__type_visibility__) {
+            ffi define _LIBCXXABI_TYPE_VIS: __attribute__((__type_visibility__("default")));
+        } else {
+            ffi define _LIBCXXABI_TYPE_VIS: __attribute__((__visibility__("default")));
+        }
+    }
+} else {
+    ffi define _LIBCXXABI_HIDDEN;
+    ffi define _LIBCXXABI_DATA_VIS;
+    ffi define _LIBCXXABI_FUNC_VIS;
+    ffi define _LIBCXXABI_TYPE_VIS;
+
+    eval if defined(_LIBCXXABI_COMPILER_MSVC) {
+        ffi define _LIBCXXABI_WEAK;
+    } else {
+        ffi define _LIBCXXABI_WEAK: __attribute__((__weak__));
+    }
+
+    eval if defined(__clang__) {
+        ffi define _LIBCXXABI_COMPILER_CLANG;
+    } else if defined(__GNUC__) {
+        ffi define _LIBCXXABI_COMPILER_GCC;
+    }
+
+    eval if __has_attribute(__no_sanitize__) && defined(_LIBCXXABI_COMPILER_CLANG) {
+        ffi define _LIBCXXABI_NO_CFI: __attribute__((__no_sanitize__("cfi")));
+    } else {
+        ffi define _LIBCXXABI_NO_CFI;
+    }
+
+    // wasm32 follows the arm32 ABI convention of using 32-bit guard.
+    eval if defined(__arm__) || defined(__wasm32__) || defined(__ARM64_ARCH_8_32__) {
+        ffi define _LIBCXXABI_GUARD_ABI_ARM;
+    }
+
+    eval if defined(_LIBCXXABI_COMPILER_CLANG) {
+        eval if !__has_feature(cxx_exceptions) {
+            ffi define _LIBCXXABI_NO_EXCEPTIONS;
+        }
+    } else if defined(_LIBCXXABI_COMPILER_GCC) && !defined(__EXCEPTIONS) {
+        ffi define _LIBCXXABI_NO_EXCEPTIONS;
+    }
+
+    eval if defined(_WIN32) {
+        ffi define _LIBCXXABI_DTOR_FUNC: __thiscall;
+    } else {
+        ffi define _LIBCXXABI_DTOR_FUNC;
+    }
+} // ____CXXABI_CONFIG_H

--- a/helix/pkgs/libcxx_abi.hlx
+++ b/helix/pkgs/libcxx_abi.hlx
@@ -1,0 +1,145 @@
+//===----------------------------------------------------------------------===//
+//
+// Port of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+ffi define __CXXABI_H;
+
+/*
+ * This header provides the interface to the C++ ABI as defined at:
+ *       https://itanium-cxx-abi.github.io/cxx-abi/
+ */
+
+ffi "c" import "stdlib";
+ffi "c" import "stdint";
+
+import cxxabi_config;
+
+ffi define _LIBCPPABI_VERSION: 15000;
+ffi define _LIBCXXABI_NORETURN: __attribute__((noreturn));
+ffi define _LIBCXXABI_ALWAYS_COLD: __attribute__((cold));
+
+eval if defined!(__cplusplus) {
+    module std {
+        eval if defined!(_WIN32) {
+            class type_info { // forward declaration
+                // visibility attributes can be added here if needed
+            }
+        } else {
+            class type_info { // forward declaration
+                // visibility attributes can be added here if needed
+            }
+        }
+    }
+
+    // runtime routines use C calling conventions, but are in __cxxabiv1 module
+    module __cxxabiv1 {
+        struct __cxa_exception;
+
+        ffi "C" {
+            // 2.4.2 Allocating the Exception Object
+            fn __cxa_allocate_exception(thrown_size: size_t) -> *void throw;
+            fn __cxa_free_exception(thrown_exception: *void) throw;
+
+            // This function is an LLVM extension, which mirrors the same extension in libsupc++ and libcxxrt
+            fn __cxa_init_primary_exception(object: *void, tinfo: *std::type_info, dest: fn(*void)) -> *__cxa_exception throw;
+
+            // 2.4.3 Throwing the Exception Object
+            fn __cxa_throw(thrown_exception: *void, tinfo: *std::type_info, dest: fn(*void)) _LIBCXXABI_NORETURN;
+
+            eval if defined!(__USING_WASM_EXCEPTIONS__) {
+                // In Wasm, a destructor returns its argument
+                fn __cxa_throw(thrown_exception: *void, tinfo: *std::type_info, dest: fn(*void) -> *void) _LIBCXXABI_NORETURN;
+            }
+
+            // 2.5.3 Exception Handlers
+            fn __cxa_get_exception_ptr(exceptionObject: *void) -> *void throw;
+            fn __cxa_begin_catch(exceptionObject: *void) -> *void throw;
+            fn __cxa_end_catch() void;
+            
+            eval if defined!(_LIBCXXABI_ARM_EHABI) {
+                fn __cxa_begin_cleanup(exceptionObject: *void) -> bool throw;
+                fn __cxa_end_cleanup() void;
+            }
+            
+            fn __cxa_current_exception_type() -> *std::type_info;
+
+            // 2.5.4 Rethrowing Exceptions
+            fn __cxa_rethrow() _LIBCXXABI_NORETURN;
+
+            // 2.6 Auxiliary Runtime APIs
+            fn __cxa_bad_cast() _LIBCXXABI_NORETURN;
+            fn __cxa_bad_typeid() _LIBCXXABI_NORETURN;
+            fn __cxa_throw_bad_array_new_length() _LIBCXXABI_NORETURN;
+
+            // 3.2.6 Pure Virtual Function API
+            fn __cxa_pure_virtual() _LIBCXXABI_NORETURN;
+
+            // 3.2.7 Deleted Virtual Function API
+            fn __cxa_deleted_virtual() _LIBCXXABI_NORETURN;
+
+            // 3.3.2 One-time Construction API
+            eval if defined!(_LIBCXXABI_GUARD_ABI_ARM) {
+                fn __cxa_guard_acquire(guard: *u32) -> i32 _LIBCXXABI_ALWAYS_COLD;
+                fn __cxa_guard_release(guard: *u32) _LIBCXXABI_ALWAYS_COLD;
+                fn __cxa_guard_abort(guard: *u32) _LIBCXXABI_ALWAYS_COLD;
+            } else {
+                fn __cxa_guard_acquire(guard: *u64) -> i32 _LIBCXXABI_ALWAYS_COLD;
+                fn __cxa_guard_release(guard: *u64) _LIBCXXABI_ALWAYS_COLD;
+                fn __cxa_guard_abort(guard: *u64) _LIBCXXABI_ALWAYS_COLD;
+            }
+
+            // 3.3.3 Array Construction and Destruction API
+            fn __cxa_vec_new(element_count: size_t, element_size: size_t, padding_size: size_t, constructor: fn(*void), destructor: fn(*void)) -> *void;
+
+            fn __cxa_vec_new2(element_count: size_t, element_size: size_t, padding_size: size_t, constructor: fn(*void), destructor: fn(*void), alloc: fn(size_t) -> *void, dealloc: fn(*void)) -> *void;
+
+            fn __cxa_vec_new3(element_count: size_t, element_size: size_t, padding_size: size_t, constructor: fn(*void), destructor: fn(*void), alloc: fn(size_t) -> *void, dealloc: fn(*void, size_t)) -> *void;
+
+            fn __cxa_vec_ctor(array_address: *void, element_count: size_t, element_size: size_t, constructor: fn(*void), destructor: fn(*void)) void;
+
+            fn __cxa_vec_dtor(array_address: *void, element_count: size_t, element_size: size_t, destructor: fn(*void)) void;
+
+            fn __cxa_vec_cleanup(array_address: *void, element_count: size_t, element_size: size_t, destructor: fn(*void)) void;
+
+            fn __cxa_vec_delete(array_address: *void, element_size: size_t, padding_size: size_t, destructor: fn(*void)) void;
+
+            fn __cxa_vec_delete2(array_address: *void, element_size: size_t, padding_size: size_t, destructor: fn(*void), dealloc: fn(*void)) void;
+
+            fn __cxa_vec_delete3(array_address: *void, element_size: size_t, padding_size: size_t, destructor: fn(*void), dealloc: fn(*void, size_t)) void;
+
+            fn __cxa_vec_cctor(dest_array: *void, src_array: *void, element_count: size_t, element_size: size_t, constructor: fn(*void, *void), destructor: fn(*void)) void;
+
+            // 3.3.5.3 Runtime API
+            // These functions are part of the C++ ABI, but they are not defined in libc++abi:
+            //    int __cxa_atexit(fn(*void), *void, *void);
+            //    void __cxa_finalize(*void);
+
+            // 3.4 Demangler API
+            fn __cxa_demangle(mangled_name: *char, output_buffer: *char, length: *size_t, status: *int) -> *char;
+
+            // Apple additions to support C++ 0x exception_ptr class
+            // These are primitives to wrap a smart pointer around an exception object
+            fn __cxa_current_primary_exception() -> *void throw;
+            fn __cxa_rethrow_primary_exception(primary_exception: *void);
+            fn __cxa_increment_exception_refcount(primary_exception: *void) throw;
+            fn __cxa_decrement_exception_refcount(primary_exception: *void) throw;
+
+            // Apple extension to support std::uncaught_exception()
+            fn __cxa_uncaught_exception() -> bool throw;
+            fn __cxa_uncaught_exceptions() -> u32 throw;
+
+            eval if defined!(__linux__) || defined!(__Fuchsia__) {
+                // Linux and Fuchsia TLS support. Not yet an official part of the Itanium ABI.
+                // https://sourceware.org/glibc/wiki/Destructor%20support%20for%20thread_local%20variables
+                fn __cxa_thread_atexit(fn(*void), *void, *void) -> i32 throw;
+            }
+
+        } // ffi "C"
+    } // module __cxxabiv1
+
+    module abi = __cxxabiv1;
+}


### PR DESCRIPTION
- Translated the C++ ABI interface definitions from libcxx to Helix
- Included necessary imports for C standard libraries (stdlib, stdint)
- Defined forward declarations for `type_info` class in the `std` namespace
- Implemented `__cxxabiv1` namespace with function declarations
- Ensured compatibility with Helix's syntax and conventions
- Added attributes for `noreturn` and `cold` functions
- Preserved exception handling and array management functions
- Maintained visibility attributes and linkage for C++ interoperability

This port provides the Helix equivalent of the libcxx ABI, enabling Helix to interface with libcxx as defined in the Itanium C++ ABI.